### PR TITLE
Fix tetradic color harmony implementation 

### DIFF
--- a/src/projects/02-complementary-colors/utils/colorUtils.js
+++ b/src/projects/02-complementary-colors/utils/colorUtils.js
@@ -141,12 +141,19 @@ export const calculateTetradic = (hexColor) => {
   const [h, s, l] = rgbToHsl(rgb.r, rgb.g, rgb.b);
   
   const colors = [];
-  // Generate 4 tetradic colors (90° apart)
-  for (let i = 0; i < 4; i++) {
-    const newH = (h + i * 90) % 360;
-    const [r, g, b] = hslToRgb(newH, s, l);
-    colors.push(rgbToHex(r, g, b));
-  }
+  // Generate 4 tetradic colors (2 pairs of complementary colors)
+  // First pair: base color and its complement
+  const [r1, g1, b1] = hslToRgb(h, s, l);
+  const [r2, g2, b2] = hslToRgb((h + 180) % 360, s, l);
+  
+  // Second pair: offset by 30° from the first pair
+  const [r3, g3, b3] = hslToRgb((h + 30) % 360, s, l);
+  const [r4, g4, b4] = hslToRgb((h + 210) % 360, s, l);
+  
+  colors.push(rgbToHex(r1, g1, b1));
+  colors.push(rgbToHex(r2, g2, b2));
+  colors.push(rgbToHex(r3, g3, b3));
+  colors.push(rgbToHex(r4, g4, b4));
   
   return colors;
 };


### PR DESCRIPTION
Differentiate from square harmony

- Updated calculateTetradic function to create rectangular color scheme
- Tetradic now uses 2 pairs of complementary colors offset by 30
- Square harmony remains as 4 colors evenly spaced (90 apart)
- This aligns with proper color theory where tetradic forms a rectangle and square forms a perfect square