### PR TITLE
fix: Resolve ESLint warnings and deprecation issues

### DIFF
--- a/src/projects/02-complementary-colors/ComplementaryColorsApp.jsx
+++ b/src/projects/02-complementary-colors/ComplementaryColorsApp.jsx
@@ -2,8 +2,6 @@ import React, { useState } from 'react';
 import ColorPicker from './components/ColorPicker';
 import HarmonyDisplay from './components/HarmonyDisplay';
 import { calculateHarmony } from './utils/colorUtils';
-import Title from '../components/Title';
-import Description from '../components/Description';
 import SEO from '../../components/SEO';
 
 const ComplementaryColorsApp = () => {
@@ -31,21 +29,21 @@ const ComplementaryColorsApp = () => {
 
   return (
     <>
-      <SEO 
+      <SEO
         title="Complementary Colors Tool - Color Harmony Generator"
         description="Explore color harmonies with our interactive complementary colors tool. Generate complementary, monochromatic, analogous, triadic, and tetradic color schemes."
         keywords="color harmony, complementary colors, color theory, color wheel, color schemes, design tools"
         type="website"
         author="Ovidiu Alexandru Pușcaș"
       />
-      
+
       <div className="bg-gray-50 py-8 px-4">
         <div className="max-w-6xl mx-auto">
-          
+
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
             {/* Color Picker Section */}
             <div className="space-y-6">
-              <ColorPicker 
+              <ColorPicker
                 selectedColor={selectedColor}
                 onColorChange={handleColorChange}
                 onHarmonyChange={handleHarmonyChange}
@@ -55,7 +53,7 @@ const ComplementaryColorsApp = () => {
 
             {/* Harmony Display Section */}
             <div className="space-y-6">
-              <HarmonyDisplay 
+              <HarmonyDisplay
                 colors={harmonyColors}
                 harmonyType={selectedHarmony}
                 selectedColor={selectedColor}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,5 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [
-    require('@tailwindcss/line-clamp'),
-  ],
-} 
+  plugins: [],
+}


### PR DESCRIPTION
- Remove unused imports in ComplementaryColorsApp (Title, Description)
- Remove deprecated @tailwindcss/line-clamp plugin (now included by default in v3.3+)
- Clean build with no ESLint warnings
- Production-ready codebase with proper linting compliance